### PR TITLE
Adding support for multiple access token signing keys (CDI 2.9)

### DIFF
--- a/src/SuperTokens.AspNetCore/AccessTokenSigningKey.cs
+++ b/src/SuperTokens.AspNetCore/AccessTokenSigningKey.cs
@@ -20,7 +20,9 @@ namespace SuperTokens.AspNetCore
         public DateTimeOffset Creation { get; }
 
         public override bool Equals(object? obj) => this.Equals(obj as AccessTokenSigningKey);
-        public bool Equals(AccessTokenSigningKey? other) => other != null && this.PublicKey == other.PublicKey && this.Expiration.Equals(other.Expiration) && this.Creation.Equals(other.Creation);
+
+        // We do not consider the creation time during equality check: this information is not available on old APIs.
+        public bool Equals(AccessTokenSigningKey? other) => other != null && this.PublicKey == other.PublicKey && this.Expiration.Equals(other.Expiration);
         public override int GetHashCode() => HashCode.Combine(this.PublicKey, this.Expiration, this.Creation);
     }
 }

--- a/src/SuperTokens.AspNetCore/AccessTokenSigningKey.cs
+++ b/src/SuperTokens.AspNetCore/AccessTokenSigningKey.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace SuperTokens.AspNetCore
+{
+    public sealed class AccessTokenSigningKey : IEquatable<AccessTokenSigningKey?>
+    {
+        public AccessTokenSigningKey(
+            string publicKey,
+            DateTimeOffset expiration,
+            DateTimeOffset creation)
+        {
+            this.PublicKey = publicKey;
+            this.Expiration = expiration;
+            this.Creation = creation;
+        }
+
+        public string PublicKey { get; }
+
+        public DateTimeOffset Expiration { get; }
+        public DateTimeOffset Creation { get; }
+
+        public override bool Equals(object? obj) => this.Equals(obj as AccessTokenSigningKey);
+        public bool Equals(AccessTokenSigningKey? other) => other != null && this.PublicKey == other.PublicKey && this.Expiration.Equals(other.Expiration) && this.Creation.Equals(other.Creation);
+        public override int GetHashCode() => HashCode.Combine(this.PublicKey, this.Expiration, this.Creation);
+    }
+}

--- a/src/SuperTokens.AspNetCore/ApiVersionContainer.cs
+++ b/src/SuperTokens.AspNetCore/ApiVersionContainer.cs
@@ -15,7 +15,7 @@ namespace SuperTokens.AspNetCore
 
         private static readonly TimeSpan RetryRefreshInterval = new(0, 0, 5, 0, 0);
 
-        private static readonly string[] SupportedApiVersions = new[] { "2.7" };
+        private static readonly string[] SupportedApiVersions = new[] { "2.9", "2.8", "2.7" };
 
         private readonly ISystemClock _clock;
 

--- a/src/SuperTokens.AspNetCore/Handshake.cs
+++ b/src/SuperTokens.AspNetCore/Handshake.cs
@@ -1,30 +1,36 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace SuperTokens.AspNetCore
 {
     public sealed class Handshake
     {
+        private ImmutableArray<AccessTokenSigningKey> accessTokenSigningPublicKeyList;
+
         public Handshake(
-            string jwtSigningPublicKey,
-            DateTimeOffset jwtSigningPublicKeyExpiration,
+            IEnumerable<AccessTokenSigningKey> jwtSigningPublicKeyList,
             bool accessTokenBlacklistingEnabled,
             TimeSpan accessTokenLifetime,
             TimeSpan refreshTokenLifetime)
         {
-            this.JwtSigningPublicKey = jwtSigningPublicKey;
-            this.JwtSigningPublicKeyExpiration = jwtSigningPublicKeyExpiration;
+            this.AccessTokenSigningPublicKeyList = ImmutableArray.ToImmutableArray(jwtSigningPublicKeyList);
+
             this.AccessTokenBlacklistingEnabled = accessTokenBlacklistingEnabled;
             this.AccessTokenLifetime = accessTokenLifetime;
             this.RefreshTokenLifetime = refreshTokenLifetime;
         }
 
+        public ImmutableArray<AccessTokenSigningKey> AccessTokenSigningPublicKeyList
+        {
+            get => accessTokenSigningPublicKeyList.Where(keyInfo => keyInfo.Expiration > DateTimeOffset.Now).ToImmutableArray();
+            private set => accessTokenSigningPublicKeyList = value;
+        }
+
         public bool AccessTokenBlacklistingEnabled { get; }
 
         public TimeSpan AccessTokenLifetime { get; }
-
-        public string JwtSigningPublicKey { get; }
-
-        public DateTimeOffset JwtSigningPublicKeyExpiration { get; }
 
         public TimeSpan RefreshTokenLifetime { get; }
     }

--- a/src/SuperTokens.AspNetCore/Handshake.cs
+++ b/src/SuperTokens.AspNetCore/Handshake.cs
@@ -7,7 +7,7 @@ namespace SuperTokens.AspNetCore
 {
     public sealed class Handshake
     {
-        private ImmutableArray<AccessTokenSigningKey> accessTokenSigningPublicKeyList;
+        private ImmutableArray<AccessTokenSigningKey> _accessTokenSigningPublicKeyList;
 
         public Handshake(
             IEnumerable<AccessTokenSigningKey> jwtSigningPublicKeyList,
@@ -15,18 +15,15 @@ namespace SuperTokens.AspNetCore
             TimeSpan accessTokenLifetime,
             TimeSpan refreshTokenLifetime)
         {
-            this.AccessTokenSigningPublicKeyList = ImmutableArray.ToImmutableArray(jwtSigningPublicKeyList);
+            _accessTokenSigningPublicKeyList = ImmutableArray.ToImmutableArray(jwtSigningPublicKeyList);
 
             this.AccessTokenBlacklistingEnabled = accessTokenBlacklistingEnabled;
             this.AccessTokenLifetime = accessTokenLifetime;
             this.RefreshTokenLifetime = refreshTokenLifetime;
         }
 
-        public ImmutableArray<AccessTokenSigningKey> AccessTokenSigningPublicKeyList
-        {
-            get => accessTokenSigningPublicKeyList.Where(keyInfo => keyInfo.Expiration > DateTimeOffset.Now).ToImmutableArray();
-            private set => accessTokenSigningPublicKeyList = value;
-        }
+        public ImmutableArray<AccessTokenSigningKey> GetAccessTokenSigningPublicKeyList(DateTimeOffset now) =>
+            _accessTokenSigningPublicKeyList.Where(keyInfo => keyInfo.Expiration > now).ToImmutableArray();
 
         public bool AccessTokenBlacklistingEnabled { get; }
 

--- a/src/SuperTokens.AspNetCore/HandshakeContainer.cs
+++ b/src/SuperTokens.AspNetCore/HandshakeContainer.cs
@@ -34,7 +34,7 @@ namespace SuperTokens.AspNetCore
             var now = _clock.UtcNow;
 
             var handshake = _handshake;
-            if (handshake != null && handshake.AccessTokenSigningPublicKeyList.Length > 0)
+            if (handshake != null && handshake.GetAccessTokenSigningPublicKeyList(now).Length > 0)
             {
                 return handshake;
             }
@@ -42,7 +42,7 @@ namespace SuperTokens.AspNetCore
             await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                if (_handshake == null || _handshake.AccessTokenSigningPublicKeyList.Length == 0)
+                if (_handshake == null || _handshake.GetAccessTokenSigningPublicKeyList(now).Length == 0)
                 {
                     try
                     {
@@ -104,6 +104,7 @@ namespace SuperTokens.AspNetCore
                 return;
             }
 
+            var now = _clock.UtcNow;
             var updatedSigningPublicKeyList = jwtSigningPublicKeyList != null
                 ? jwtSigningPublicKeyList.Select(keyInfo =>
                     new AccessTokenSigningKey(keyInfo.publicKey,
@@ -113,10 +114,10 @@ namespace SuperTokens.AspNetCore
                 : new[] {
                     new AccessTokenSigningKey(jwtSigningPublicKey,
                         jwtSigningPublicKeyExpiration,
-                        _clock.UtcNow
+                        now
                 )};
 
-            if (handshake.AccessTokenSigningPublicKeyList.SequenceEqual(updatedSigningPublicKeyList))
+            if (handshake.GetAccessTokenSigningPublicKeyList(now).SequenceEqual(updatedSigningPublicKeyList))
             {
                 return;
             }
@@ -124,7 +125,7 @@ namespace SuperTokens.AspNetCore
             await _refreshLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                if (_handshake != null && !handshake.AccessTokenSigningPublicKeyList.SequenceEqual(updatedSigningPublicKeyList))
+                if (_handshake != null && !handshake.GetAccessTokenSigningPublicKeyList(now).SequenceEqual(updatedSigningPublicKeyList))
                 {
                     _handshake = new Handshake(
                         updatedSigningPublicKeyList,

--- a/src/SuperTokens.AspNetCore/IHandshakeContainer.cs
+++ b/src/SuperTokens.AspNetCore/IHandshakeContainer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,6 +9,6 @@ namespace SuperTokens.AspNetCore
     {
         Task<Handshake> GetHandshakeAsync(string? apiKey, string? cdiVersion, CancellationToken cancellationToken);
 
-        Task OnHandshakeChanged(string jwtSigningPublicKey, DateTimeOffset jwtSigningPublicKeyExpiration);
+        Task OnHandshakeChanged(IEnumerable<Net.SessionRecipe.KeyInfo>? jwtSigningPublicKeyList, string jwtSigningPublicKey, DateTimeOffset jwtSigningPublicKeyExpiration);
     }
 }

--- a/src/SuperTokens.AspNetCore/SessionRecipe.cs
+++ b/src/SuperTokens.AspNetCore/SessionRecipe.cs
@@ -52,7 +52,7 @@ namespace SuperTokens.AspNetCore
                 throw new InvalidOperationException("Failed to login the user.");
             }
 
-            await _handshakeContainer.OnHandshakeChanged(result.JwtSigningPublicKey, DateTimeOffset.FromUnixTimeMilliseconds(result.JwtSigningPublicKeyExpiryTime));
+            await _handshakeContainer.OnHandshakeChanged(result.JwtSigningPublicKeyList, result.JwtSigningPublicKey, DateTimeOffset.FromUnixTimeMilliseconds(result.JwtSigningPublicKeyExpiryTime));
 
             var context = _httpContextAccessor.HttpContext ?? throw new InvalidOperationException("The session recipe only works in a HTTP context.");
             if (context.Response.HasStarted)

--- a/src/SuperTokens.AspNetCore/SuperTokensHandler.cs
+++ b/src/SuperTokens.AspNetCore/SuperTokensHandler.cs
@@ -167,7 +167,7 @@ namespace SuperTokens.AspNetCore
 
             var foundSigningKeyOlderThanToken = false;
             var isSignatureValid = false;
-            foreach (var keyInfo in handshake.AccessTokenSigningPublicKeyList)
+            foreach (var keyInfo in handshake.GetAccessTokenSigningPublicKeyList(now))
             {
                 if (JwtUtilities.Validate(components, keyInfo.PublicKey))
                 {

--- a/src/SuperTokens.Net/SessionRecipe/CreateSessionResponse.cs
+++ b/src/SuperTokens.Net/SessionRecipe/CreateSessionResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace SuperTokens.Net.SessionRecipe
 {
@@ -12,6 +13,9 @@ namespace SuperTokens.Net.SessionRecipe
 
         [JsonPropertyName("idRefreshToken")]
         public Core.CookieInfo IdRefreshToken { get; set; } = null!;
+
+        [JsonPropertyName("jwtSigningPublicKeyList")]
+        public List<KeyInfo>? JwtSigningPublicKeyList { get; set; } = null;
 
         [JsonPropertyName("jwtSigningPublicKey")]
         public string JwtSigningPublicKey { get; set; } = null!;

--- a/src/SuperTokens.Net/SessionRecipe/Handshake.cs
+++ b/src/SuperTokens.Net/SessionRecipe/Handshake.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace SuperTokens.Net.SessionRecipe
 {
@@ -9,6 +10,9 @@ namespace SuperTokens.Net.SessionRecipe
 
         [JsonPropertyName("accessTokenValidity")]
         public long AccessTokenValidity { get; set; }
+
+        [JsonPropertyName("jwtSigningPublicKeyList")]
+        public List<KeyInfo>? JwtSigningPublicKeyList { get; set; } = null;
 
         [JsonPropertyName("jwtSigningPublicKey")]
         public string JwtSigningPublicKey { get; set; } = null!;

--- a/src/SuperTokens.Net/SessionRecipe/KeyInfo.cs
+++ b/src/SuperTokens.Net/SessionRecipe/KeyInfo.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SuperTokens.Net.SessionRecipe
+{
+    public class KeyInfo
+    {
+        [JsonPropertyName("publicKey")]
+        public string publicKey { get; set; }
+
+
+        [JsonPropertyName("expiryTime")]
+        public long expirationTime { get; set; }
+
+        [JsonPropertyName("createdAt")]
+        public long createdAt { get; set; }
+    }
+}

--- a/src/SuperTokens.Net/SessionRecipe/VerifySessionResponse.cs
+++ b/src/SuperTokens.Net/SessionRecipe/VerifySessionResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace SuperTokens.Net.SessionRecipe
 {
@@ -6,6 +7,9 @@ namespace SuperTokens.Net.SessionRecipe
     {
         [JsonPropertyName("accessToken")]
         public Core.CookieInfo? AccessToken { get; set; }
+
+        [JsonPropertyName("jwtSigningPublicKeyList")]
+        public List<KeyInfo>? JwtSigningPublicKeyList { get; set; } = null;
 
         [JsonPropertyName("jwtSigningPublicKey")]
         public string JwtSigningPublicKey { get; set; } = null!;


### PR DESCRIPTION
Adding support for multiple access token signing keys (CDI 2.9). This PR will smooth out the request spikes at signing key changes.