### PR TITLE
Sending cdi version with requests

### DIFF
--- a/src/SuperTokens.AspNetCore/ApiVersionContainer.cs
+++ b/src/SuperTokens.AspNetCore/ApiVersionContainer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -15,7 +16,7 @@ namespace SuperTokens.AspNetCore
 
         private static readonly TimeSpan RetryRefreshInterval = new(0, 0, 5, 0, 0);
 
-        private static readonly string[] SupportedApiVersions = new[] { "2.7" };
+        private static readonly string[] SupportedApiVersions = new[] { "2.7" }.OrderByDescending(str => new Version(str)).ToArray();
 
         private readonly ISystemClock _clock;
 

--- a/src/SuperTokens.AspNetCore/ApiVersionContainer.cs
+++ b/src/SuperTokens.AspNetCore/ApiVersionContainer.cs
@@ -9,7 +9,7 @@ using SuperTokens.Net;
 
 namespace SuperTokens.AspNetCore
 {
-    internal sealed class ApiVersionContainer : BackgroundService
+    internal sealed class ApiVersionContainer : BackgroundService, IApiVersionContainer
     {
         private static readonly TimeSpan AutomaticRefreshInterval = new(0, 12, 0, 0, 0);
 
@@ -42,6 +42,11 @@ namespace SuperTokens.AspNetCore
             return apiVersion != null
                 ? ValueTask.FromResult(apiVersion)
                 : new ValueTask<string>(this.RefreshApiVersionAsync(cancellationToken));
+        }
+
+        public ValueTask<string> GetApiVersionAsync()
+        {
+            return this.GetApiVersionAsync(CancellationToken.None);
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/SuperTokens.AspNetCore/DependencyInjection/SuperTokensExtensions.cs
+++ b/src/SuperTokens.AspNetCore/DependencyInjection/SuperTokensExtensions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(builder));
             }
-
+            builder.Services.TryAddSingleton<IApiVersionContainer, ApiVersionContainer>();
             builder.Services.TryAddSingleton<IHandshakeContainer, HandshakeContainer>();
             builder.Services.TryAddScoped<ISessionAccessor, SessionAccessor>();
             builder.Services.TryAddScoped<ISessionRecipe, SessionRecipe>();

--- a/src/SuperTokens.AspNetCore/IApiVersionContainer.cs
+++ b/src/SuperTokens.AspNetCore/IApiVersionContainer.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace SuperTokens.AspNetCore
+{
+    public interface IApiVersionContainer
+    {
+        ValueTask<string> GetApiVersionAsync(CancellationToken cancellationToken);
+        ValueTask<string> GetApiVersionAsync();
+    }
+}

--- a/src/SuperTokens.AspNetCore/SessionRecipe.cs
+++ b/src/SuperTokens.AspNetCore/SessionRecipe.cs
@@ -14,6 +14,7 @@ namespace SuperTokens.AspNetCore
     public class SessionRecipe : ISessionRecipe
     {
         private readonly ICoreApiClient _coreApiClient;
+        private readonly IApiVersionContainer _apiVersionContainer;
 
         private readonly IHandshakeContainer _handshakeContainer;
 
@@ -23,13 +24,14 @@ namespace SuperTokens.AspNetCore
 
         private readonly ISessionAccessor _sessionAccessor;
 
-        public SessionRecipe(ICoreApiClient coreApiClient, IHandshakeContainer handshakeContainer, ISessionAccessor sessionAccessor, IHttpContextAccessor httpContextAccessor, IOptionsMonitor<SuperTokensOptions> options)
+        public SessionRecipe(ICoreApiClient coreApiClient, IHandshakeContainer handshakeContainer, ISessionAccessor sessionAccessor, IHttpContextAccessor httpContextAccessor, IOptionsMonitor<SuperTokensOptions> options, IApiVersionContainer apiVersionContainer)
         {
             _coreApiClient = coreApiClient ?? throw new ArgumentNullException(nameof(coreApiClient));
             _handshakeContainer = handshakeContainer ?? throw new ArgumentNullException(nameof(handshakeContainer));
             _sessionAccessor = sessionAccessor ?? throw new ArgumentNullException(nameof(sessionAccessor));
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _apiVersionContainer = apiVersionContainer ?? throw new ArgumentNullException(nameof(apiVersionContainer));
         }
 
         public async Task<SuperTokensSession> AuthenticateAsync(string userId)
@@ -40,7 +42,8 @@ namespace SuperTokens.AspNetCore
             var emptyObject = document.RootElement.Clone();
             document.Dispose();
 
-            var result = await _coreApiClient.CreateSessionAsync(options.CoreApiKey, null, new CreateSessionRequest
+            var cdiVersion = await _apiVersionContainer.GetApiVersionAsync();
+            var result = await _coreApiClient.CreateSessionAsync(options.CoreApiKey, cdiVersion, new CreateSessionRequest
             {
                 EnableAntiCsrf = options.AntiCsrfMode == SuperTokensAntiCsrfMode.ViaToken,
                 UserDataInDatabase = emptyObject,


### PR DESCRIPTION
The library should send the CDI version it uses with each request to make sure that it uses a version both support.