### PR TITLE
Use API key in requests to fetch supported CDI version

### DIFF
--- a/src/SuperTokens.AspNetCore/AccessTokenSigningKey.cs
+++ b/src/SuperTokens.AspNetCore/AccessTokenSigningKey.cs
@@ -14,15 +14,17 @@ namespace SuperTokens.AspNetCore
             this.Creation = creation;
         }
 
-        public string PublicKey { get; }
+        public DateTimeOffset Creation { get; }
 
         public DateTimeOffset Expiration { get; }
-        public DateTimeOffset Creation { get; }
+
+        public string PublicKey { get; }
 
         public override bool Equals(object? obj) => this.Equals(obj as AccessTokenSigningKey);
 
         // We do not consider the creation time during equality check: this information is not available on old APIs.
         public bool Equals(AccessTokenSigningKey? other) => other != null && this.PublicKey == other.PublicKey && this.Expiration.Equals(other.Expiration);
+
         public override int GetHashCode() => HashCode.Combine(this.PublicKey, this.Expiration, this.Creation);
     }
 }

--- a/src/SuperTokens.AspNetCore/DependencyInjection/SuperTokensExtensions.cs
+++ b/src/SuperTokens.AspNetCore/DependencyInjection/SuperTokensExtensions.cs
@@ -61,10 +61,13 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(builder));
             }
-            builder.Services.TryAddSingleton<IApiVersionContainer, ApiVersionContainer>();
-            builder.Services.TryAddSingleton<IHandshakeContainer, HandshakeContainer>();
-            builder.Services.TryAddScoped<ISessionAccessor, SessionAccessor>();
-            builder.Services.TryAddScoped<ISessionRecipe, SessionRecipe>();
+
+            builder.Services.AddSingleton<ApiVersionContainer>();
+            builder.Services.AddSingleton<IApiVersionContainer>(services => services.GetRequiredService<ApiVersionContainer>());
+            builder.Services.AddHostedService(services => services.GetRequiredService<ApiVersionContainer>());
+            builder.Services.AddSingleton<IHandshakeContainer, HandshakeContainer>();
+            builder.Services.AddScoped<ISessionAccessor, SessionAccessor>();
+            builder.Services.AddScoped<ISessionRecipe, SessionRecipe>();
             builder.Services.AddHttpClient<ICoreApiClient, CoreApiClient>((services, httpClient) =>
             {
                 var options = services.GetRequiredService<IOptionsMonitor<SuperTokensOptions>>().Get(authenticationScheme);

--- a/src/SuperTokens.AspNetCore/Handshake.cs
+++ b/src/SuperTokens.AspNetCore/Handshake.cs
@@ -22,13 +22,13 @@ namespace SuperTokens.AspNetCore
             this.RefreshTokenLifetime = refreshTokenLifetime;
         }
 
-        public ImmutableArray<AccessTokenSigningKey> GetAccessTokenSigningPublicKeyList(DateTimeOffset now) =>
-            _accessTokenSigningPublicKeyList.Where(keyInfo => keyInfo.Expiration > now).ToImmutableArray();
-
         public bool AccessTokenBlacklistingEnabled { get; }
 
         public TimeSpan AccessTokenLifetime { get; }
 
         public TimeSpan RefreshTokenLifetime { get; }
+
+        public ImmutableArray<AccessTokenSigningKey> GetAccessTokenSigningPublicKeyList(DateTimeOffset now) =>
+            _accessTokenSigningPublicKeyList.Where(keyInfo => keyInfo.Expiration > now).ToImmutableArray();
     }
 }

--- a/src/SuperTokens.AspNetCore/HandshakeContainer.cs
+++ b/src/SuperTokens.AspNetCore/HandshakeContainer.cs
@@ -1,10 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using SuperTokens.Net;
@@ -28,6 +28,9 @@ namespace SuperTokens.AspNetCore
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         }
+
+        public Task<Handshake> GetHandshakeAsync(string? apiKey, string? cdiVersion) =>
+            this.GetHandshakeAsync(apiKey, cdiVersion, CancellationToken.None);
 
         public async Task<Handshake> GetHandshakeAsync(string? apiKey, string? cdiVersion, CancellationToken cancellationToken)
         {

--- a/src/SuperTokens.AspNetCore/IApiVersionContainer.cs
+++ b/src/SuperTokens.AspNetCore/IApiVersionContainer.cs
@@ -5,7 +5,8 @@ namespace SuperTokens.AspNetCore
 {
     public interface IApiVersionContainer
     {
-        ValueTask<string> GetApiVersionAsync(CancellationToken cancellationToken);
-        ValueTask<string> GetApiVersionAsync();
+        ValueTask<string> GetApiVersionAsync(string? apiKey);
+
+        ValueTask<string> GetApiVersionAsync(string? apiKey, CancellationToken cancellationToken);
     }
 }

--- a/src/SuperTokens.AspNetCore/IHandshakeContainer.cs
+++ b/src/SuperTokens.AspNetCore/IHandshakeContainer.cs
@@ -7,6 +7,8 @@ namespace SuperTokens.AspNetCore
 {
     public interface IHandshakeContainer
     {
+        Task<Handshake> GetHandshakeAsync(string? apiKey, string? cdiVersion);
+
         Task<Handshake> GetHandshakeAsync(string? apiKey, string? cdiVersion, CancellationToken cancellationToken);
 
         Task OnHandshakeChanged(IEnumerable<Net.SessionRecipe.KeyInfo>? jwtSigningPublicKeyList, string jwtSigningPublicKey, DateTimeOffset jwtSigningPublicKeyExpiration);

--- a/src/SuperTokens.AspNetCore/SessionRecipe.cs
+++ b/src/SuperTokens.AspNetCore/SessionRecipe.cs
@@ -13,8 +13,9 @@ namespace SuperTokens.AspNetCore
 {
     public class SessionRecipe : ISessionRecipe
     {
-        private readonly ICoreApiClient _coreApiClient;
         private readonly IApiVersionContainer _apiVersionContainer;
+
+        private readonly ICoreApiClient _coreApiClient;
 
         private readonly IHandshakeContainer _handshakeContainer;
 
@@ -42,7 +43,7 @@ namespace SuperTokens.AspNetCore
             var emptyObject = document.RootElement.Clone();
             document.Dispose();
 
-            var cdiVersion = await _apiVersionContainer.GetApiVersionAsync();
+            var cdiVersion = await _apiVersionContainer.GetApiVersionAsync(options.CoreApiKey);
             var result = await _coreApiClient.CreateSessionAsync(options.CoreApiKey, cdiVersion, new CreateSessionRequest
             {
                 EnableAntiCsrf = options.AntiCsrfMode == SuperTokensAntiCsrfMode.ViaToken,

--- a/src/SuperTokens.AspNetCore/SuperTokensSession.cs
+++ b/src/SuperTokens.AspNetCore/SuperTokensSession.cs
@@ -11,8 +11,8 @@
 
         public string Handle { get; }
 
-        public string UserId { get; }
-
         public string UserDataInJwt { get; }
+
+        public string UserId { get; }
     }
 }


### PR DESCRIPTION
This registers the API version container as a background service to periodically refresh the support CDI version (to cover cases where the Core is upgraded and the service is not restarted).

This also fixes sending the API key with the request to get the CDI version.